### PR TITLE
fixes no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ default = ["std"]
 std = []
 
 [dependencies]
+defmt = { version = "0.2", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,9 @@ use std::time::Instant;
 /// # fn measure() -> f64 { todo!() }
 /// # fn apply_correction(_: f64) { todo!() }
 /// ```
+
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Controller {
     target: f64,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 //! # fn apply_correction(_: f64) { todo!() }
 //! ```
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, future_incompatible, unreachable_pub, rust_2018_idioms)]


### PR DESCRIPTION
The library did not set the no_std attribute when the std feature was missing. This caused the lib to still require the std. This PR fixes this.