### PR TITLE
Use the maximum between elapsed time and 1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ impl Controller {
     /// hours, rather than on the scale of minutes to milliseconds.
     #[must_use = "A PID controller does nothing if the correction is not applied"]
     pub fn update_elapsed(&mut self, current_value: f64, elapsed: Duration) -> f64 {
-        let elapsed = (elapsed.as_millis() as f64).min(1.0);
+        let elapsed = (elapsed.as_millis() as f64).max(1.0);
 
         let error = self.target - current_value;
         let error_delta = (error - self.last_error) / elapsed;
@@ -267,8 +267,8 @@ mod test {
     fn base_correction() {
         let target = 80.0;
         let mut controller = Controller::new(target, 0.5, 0.1, 0.2);
-        let dur = Duration::from_millis(2);
-        assert_eq!(controller.update_elapsed(60.0, dur), 16.0);
+        let dur = Duration::from_millis(4);
+        assert_eq!(controller.update_elapsed(60.0, dur), 19.0);
     }
 
     #[test]


### PR DESCRIPTION
Most likely the elapsed time will always be >= 1,
so taking the minimum between that and 1 will always result in 1. But we just don't want to end up with 0 (or a negative value), so we should take the maximum.

Changed the values in the test because for both 1 and 2ms the correction will be 16, but for higher values it will change.